### PR TITLE
Make tests robust against proto semantic changes

### DIFF
--- a/t/02-routines.t
+++ b/t/02-routines.t
@@ -59,7 +59,7 @@ subtest 'tracing', {
 
     trace {
         lives-ok {
-            proto sub multi-sub() is traced {*}
+            proto sub multi-sub() is traced { {*}; Nil }
             multi sub multi-sub()           { }
             multi-sub
         }, 'traced proto routines do not throw while tracing...';
@@ -81,7 +81,7 @@ subtest 'tracing', {
 
     trace {
         lives-ok {
-            proto sub multi-sub() is traced {*}
+            proto sub multi-sub() is traced { {*} }
             multi sub multi-sub() is traced { }
             multi-sub;
         }, 'a combination of traced proto and multi routines do not throw while tracing...';
@@ -127,7 +127,7 @@ subtest 'tracing', {
             my class Foo {
                 method ^foo(\this) is traced { this.foo }
 
-                proto method foo is traced {*}
+                proto method foo is traced { {*} }
                 multi method foo is traced { self!foo }
 
                 method !foo is traced { self.&foo }

--- a/t/06-metamodel.t
+++ b/t/06-metamodel.t
@@ -62,7 +62,7 @@ subtest 'Metamodel::MultiMethodContainer', {
     trace {
         lives-ok {
             my class WithMultiMethod is traced {
-                proto method multi-method(|)     {*}
+                proto method multi-method(|)     { {*} }
                 multi method multi-method(--> 1) { }
             }.multi-method;
         }, 'can call multi methods of traced classes...';


### PR DESCRIPTION
Raku implementations are allowed to elide calling an onlystar proto so
long as they can be sure any signature type constraints will be met
(always the case in one with a signature of `|`). Rakudo at the time of
writing has rather "interesting" semantics here; whether it elided the
`proto` or not depended on the content of the multi dispatch cache at
the time of the call! It would always make at least one call to a proto
that was in theory possible to elide for the cache setup phase.

By contrast, the new dispatch mechanism handles multiple dispatch in a
rather different way, caching at callsites, and without any calls to an
onlystar proto with a signature it can prove may be elided. While there
was no spec against the former, the latter certainly seems the more
predictable!

This module depends on the current implementation detail of the `proto`
being called once even if it wouldn't be again. Thankfully, it's easy to
adapt it to the upcoming dispatch changes by making the `proto`s used in
tests not be onlystar ones, which is what this commit does.